### PR TITLE
Fixed getCertKid to return 8 bytes instead of seven

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/utils/CertificateUtils.java
+++ b/src/main/java/eu/europa/ec/dgc/utils/CertificateUtils.java
@@ -53,7 +53,7 @@ public class CertificateUtils {
     public String getCertKid(X509Certificate x509Certificate) {
         try {
             byte[] hashBytes = calculateHashBytes(x509Certificate.getEncoded());
-            byte[] kidBytes = Arrays.copyOfRange(hashBytes, 0, KID_BYTE_COUNT - 1);
+            byte[] kidBytes = Arrays.copyOfRange(hashBytes, 0, KID_BYTE_COUNT);
 
             return Base64.getEncoder().encodeToString(kidBytes);
 


### PR DESCRIPTION
I checked the docs of Arrays.copyOfRange. The second range parameter is exclusive, so the -1 needed to be removed, to get the 8 bytes.