### PR TITLE
CI-Master Job for Main Branch

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -2,7 +2,7 @@ name: Publish package to GitHub Packages
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
ci-master.yml was set to the wrong branch name.