### PR TITLE
Implement placeholder testing to be run in CI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,3 +17,5 @@ jobs:
           distribution: 'adopt'
       - name: Build package
         run: mvn install
+      - name: Test package
+        run: mvn test

--- a/src/test/java/eu/europa/ec/dgc/DgcLibAutoConfigurationTest.java
+++ b/src/test/java/eu/europa/ec/dgc/DgcLibAutoConfigurationTest.java
@@ -1,0 +1,14 @@
+package eu.europa.ec.dgc;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class DgcLibAutoConfigurationTest {
+
+  @Test
+  public void testDefineConstructor() {
+    assertNotEquals(new DgcLibAutoConfiguration(), null);
+  }
+}

--- a/src/test/java/eu/europa/ec/dgc/signing/SignedCertificateMessageBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/SignedCertificateMessageBuilderTest.java
@@ -1,0 +1,14 @@
+package eu.europa.ec.dgc.signing;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SignedCertificateMessageBuilderTest {
+
+    @Test
+    public void testDefineConstructor() {
+        assertNotEquals(new SignedCertificateMessageBuilder(), null);
+    }
+}

--- a/src/test/java/eu/europa/ec/dgc/signing/SignedCertificateMessageParserTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/SignedCertificateMessageParserTest.java
@@ -1,0 +1,14 @@
+package eu.europa.ec.dgc.signing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SignedCertificateMessageParserTest {
+
+    @Test
+    public void testDefineConstructor() {
+        assertNotEquals(new SignedCertificateMessageParser("Hello World".getBytes()), null);
+    }
+}
+

--- a/src/test/java/eu/europa/ec/dgc/utils/CertficateUtilsTest.java
+++ b/src/test/java/eu/europa/ec/dgc/utils/CertficateUtilsTest.java
@@ -1,0 +1,14 @@
+package eu.europa.ec.dgc.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CertficateUtilsTest {
+
+    @Test
+    public void testDefineConstructor() {
+        assertNotEquals(new CertificateUtils(), null);
+    }
+}
+


### PR DESCRIPTION
Contributes to the the planned issue of #8 

Delivers just placeholder because I'm still not familiar with the codebase.
And was the smallest step.

---

Create placeholder test for:
- DgcLibAutoConfigurationTest
- SignedCertificateMessageBuilderTest
- CertficateUtilsTest

Add test runner on CI for pull request.