### PR TITLE
Hotfix: Disable Uploader Certificate Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ dgc:
         path: /var/lib/ssl/ta.jks
 ```
 
+##### Disable Upload Certificate Check
+
+Because of an error in DGC Gateway the uploader certificate check can fail. Therefore property to disable the uploader
+certificate check was introduced:
+
+```yml
+dgc:
+  gateway:
+    connector:
+      disable-upload-certificate-check: false
+```
+
+This is just a workaround. This "feature" will be removed in future releases.
+
 #### Trusted Certificate Upload
 
 It is also possible to upload new trusted certificates to provide them to other member states. Therefore the
@@ -149,7 +163,7 @@ dgc:
         path: classpath:upload.p12
 ```
 
-Certificates can also be deleted from gateway. The method call is equal to uploading new certificates. Just use 
+Certificates can also be deleted from gateway. The method call is equal to uploading new certificates. Just use
 ```deleteTrustedCertificate``` instead of ```uploadTrustedCertificate```.
 
 ### Signing

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayDownloadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayDownloadConnector.java
@@ -205,6 +205,11 @@ public class DgcGatewayDownloadConnector {
     }
 
     private boolean checkUploadCertificate(TrustListItemDto trustListItem) {
+        if (properties.isDisableUploadCertificateCheck()) {
+            log.debug("Upload Certificate Check is disabled. Skipping Check.");
+            return true;
+        }
+
         SignedCertificateMessageParser parser =
             new SignedCertificateMessageParser(trustListItem.getSignature(), trustListItem.getRawData());
         X509CertificateHolder uploadCertificate = parser.getSigningCertificate();

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/config/DgcGatewayConnectorConfigProperties.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/config/DgcGatewayConnectorConfigProperties.java
@@ -35,6 +35,11 @@ public class DgcGatewayConnectorConfigProperties {
     private boolean enabled = false;
 
     /**
+     * Disables the ckeck of Uploader Certificate for downloaded DSC.
+     */
+    private boolean disableUploadCertificateCheck = false;
+
+    /**
      * Endpoint of DGCG Service (without any path segments, e.g. https://example-dgcg.ec.europa.eu)
      */
     String endpoint;


### PR DESCRIPTION
This PR introduces a new config property to disable the uploader certificate check.