### PR TITLE
Add Null Check to Download

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayDownloadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayDownloadConnector.java
@@ -214,6 +214,10 @@ public class DgcGatewayDownloadConnector {
             new SignedCertificateMessageParser(trustListItem.getSignature(), trustListItem.getRawData());
         X509CertificateHolder uploadCertificate = parser.getSigningCertificate();
 
+        if (uploadCertificate == null) {
+            return false;
+        }
+
         return trustedUploadCertificates
             .stream()
             .anyMatch(uploadCertificate::equals);


### PR DESCRIPTION
When parsing signature went wrong the Uploader-Certificate is null. This will break the whole download process.

I've added a check to filter out all null-upload-certificates.