### PR TITLE
Add BouncyCastle Provider to SecurityContext

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/signing/SignedCertificateMessageBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedCertificateMessageBuilder.java
@@ -22,6 +22,7 @@ package eu.europa.ec.dgc.signing;
 
 import java.io.IOException;
 import java.security.PrivateKey;
+import java.security.Security;
 import java.util.Base64;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,7 @@ import org.bouncycastle.cms.CMSSignedData;
 import org.bouncycastle.cms.CMSSignedDataGenerator;
 import org.bouncycastle.cms.SignerInfoGenerator;
 import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.DefaultAlgorithmNameFinder;
 import org.bouncycastle.operator.DigestCalculatorProvider;
@@ -83,6 +85,8 @@ public class SignedCertificateMessageBuilder {
      * @return Bytes of signed CMS message.
      */
     public byte[] build(boolean detached) {
+        Security.addProvider(new BouncyCastleProvider());
+
         if (payloadCertificate == null || signingCertificate == null || signingCertificatePrivateKey == null) {
             throw new RuntimeException("Message Builder is not ready");
         }

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedCertificateMessageParser.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedCertificateMessageParser.java
@@ -22,6 +22,7 @@ package eu.europa.ec.dgc.signing;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.Security;
 import java.security.cert.CertificateException;
 import java.util.Base64;
 import java.util.Collection;
@@ -36,6 +37,7 @@ import org.bouncycastle.cms.CMSSignedData;
 import org.bouncycastle.cms.CMSSignedDataGenerator;
 import org.bouncycastle.cms.SignerInformation;
 import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 
 /**
@@ -164,6 +166,8 @@ public class SignedCertificateMessageParser {
     }
 
     private void afterPropertiesSet() {
+        Security.addProvider(new BouncyCastleProvider());
+
         // Parse Base64
         byte[] cmsBytes;
         byte[] cmsPayloadBytes = null;


### PR DESCRIPTION
When validating RSA-PSS Certificates the explicit adding of BouncyCastle Provider is needed. 

This PR adresses https://github.com/eu-digital-green-certificates/dgc-testdata/issues/242