### PR TITLE
Fix HEX-Conversion

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/utils/CertificateUtils.java
+++ b/src/main/java/eu/europa/ec/dgc/utils/CertificateUtils.java
@@ -21,7 +21,6 @@
 package eu.europa.ec.dgc.utils;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
@@ -32,6 +31,7 @@ import java.util.Base64;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.util.encoders.Hex;
 import org.springframework.stereotype.Service;
 
 /**
@@ -137,15 +137,15 @@ public class CertificateUtils {
         return new JcaX509CertificateConverter().getCertificate(inputCertificate);
     }
 
-    private String calculateHash(byte[] data) throws NoSuchAlgorithmException {
+    /**
+     * Calculates SHA-256 hash of a given Byte-Array.
+     *
+     * @param data data to hash.
+     * @return HEX-String with the hash of the data.
+     */
+    public String calculateHash(byte[] data) throws NoSuchAlgorithmException {
         byte[] certHashBytes = MessageDigest.getInstance("SHA-256").digest(data);
-        String hexString = new BigInteger(1, certHashBytes).toString(16);
-
-        if (hexString.length() == 63) {
-            hexString = "0" + hexString;
-        }
-
-        return hexString;
+        return Hex.toHexString(certHashBytes);
     }
 
     private byte[] calculateHashBytes(byte[] data) throws NoSuchAlgorithmException {

--- a/src/test/java/eu/europa/ec/dgc/utils/CertificateUtilsTest.java
+++ b/src/test/java/eu/europa/ec/dgc/utils/CertificateUtilsTest.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -51,11 +52,6 @@ public class CertificateUtilsTest {
         certificateUtils = new CertificateUtils();
         keyPair = KeyPairGenerator.getInstance("ec").generateKeyPair();
         certificate = CertificateTestUtils.generateCertificate(keyPair, "DE", "PayloadCertificate");
-    }
-
-    @Test
-    void testDefineConstructor() {
-        assertNotNull(new CertificateUtils());
     }
 
     @Test
@@ -86,6 +82,15 @@ public class CertificateUtilsTest {
         byte[] thumbprint = Hex.decode(certificateUtils.getCertThumbprint(certificate));
 
         Assertions.assertArrayEquals(expectedThumbprint, thumbprint);
+    }
+
+    @Test
+    void testHashingLeadingZero() throws NoSuchAlgorithmException {
+
+        byte[] bytes = Hex.decode("0def64b0223f86d746cc4406000a625dc550fe7b4d0df9c7e399571909d7c182");
+        String expectedHash = "00dcf2cf8e89a076becfc54327c3a9135babcce006232aab10ee0b5365e078c7";
+
+        Assertions.assertEquals(expectedHash, certificateUtils.calculateHash(bytes));
     }
 
     @Test


### PR DESCRIPTION
This PR merges a fix in HEX-String conversion. When the SHA-256 Hash started with 0-Byte the leading zeros were stripped.
with this Change they will be preserved.

This pr fixes #53 